### PR TITLE
BUGFIX: Fix examples for URI ViewHelpers

### DIFF
--- a/Documentation/Fluid/ViewHelper/Uri/Action.rst
+++ b/Documentation/Fluid/ViewHelper/Uri/Action.rst
@@ -123,4 +123,4 @@ Beispiel
 
 ::
 
- <f:link.action action="show">Zeige Details</f:link.action>
+{f:uri.action(action: 'show')}

--- a/Documentation/Fluid/ViewHelper/Uri/Email.rst
+++ b/Documentation/Fluid/ViewHelper/Uri/Email.rst
@@ -32,4 +32,4 @@ Eigenschaften
 Beispiel
 --------
 
-<f:link.email email="meine@mailadresse.tld" />
+{f:uri.email(email: 'meine@mailadresse.tld')}

--- a/Documentation/Fluid/ViewHelper/Uri/External.rst
+++ b/Documentation/Fluid/ViewHelper/Uri/External.rst
@@ -42,4 +42,4 @@ Eigenschaften
 Beispiel
 --------
 
-<f:link.external uri="www.example.com">Externer Link zu meiner Seite</f:link.external>
+{f:uri.external(uri: 'www.example.com')}


### PR DESCRIPTION
As link ViewHelpers were used in examples before, as reported by Philipp
Parzer

Fixes TYPO3-Documentation/t3SphinxThemeRtd#23