### PR TITLE
Update Date.rst: new property, formats, examples.

### DIFF
--- a/Documentation/Fluid/ViewHelper/Format/Date.rst
+++ b/Documentation/Fluid/ViewHelper/Format/Date.rst
@@ -3,7 +3,7 @@
 f:format.date
 =============
 
-Konvertiert einen Timestamp in einen lesbaren Datumswert.
+This Format/DateViewHelper produces date-time strings in a variety of formats.
 
 Properties
 ----------
@@ -14,7 +14,7 @@ date
     Mixed
 
 :aspect:`Description`
-    Either an object of type DateTime, or a text/date which can be converted to a DateTime object. e.g. 17.01.1979 is acceptable, 17.01.79 isn't.
+    A DateTime object or a string this ViewHelper converts to a DateTime object. This date can be a textual relative time description. If date is null, this ViewHelper returns an empty string. If date is an empty string as of TYPO3 CMS 7, this ViewHelper treats date as 'now'. If date is an integer, this ViewHelper interprets the integer as a Unix timestamp, converts it to a DateTime object, then applies the default timezone from the PHP function date_default_timezone_get() (http://php.net/manual/en/function.date-default-timezone-get.php).
 
 :aspect:`Default value`
     NULL
@@ -28,42 +28,103 @@ format
     String
 
 :aspect:`Description`
-    How should the date be output? The format syntax is identical to the strftime function in PHP (https://secure.php.net/manual/en/function.strftime.php).
+    The desired form of the produced time string. If there is at least one % character in the format string, this ViewHelper will use the rules of PHP's strftime() function (https://secure.php.net/manual/en/function.strftime.php). Otherwise, this ViewHelper will use the rules of PHP's date() function (http://php.net/manual/en/function.date.php).
 
 :aspect:`Default value`
-    Y-m-d
+    Firstly the value in $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'] or lastly 'Y-m-d'.
 
 :aspect:`Mandatory`
     No
 
-Although the process with DateTime objects is pretty good, make sure that the value is checked precisely. You can use 
-online tools like a timestamp convertor, or validate the value by comparison with the value in your database. The 
-documentation cites that if you want to convert a timestamp to a DateTime object, then prefix it with an @ character. 
-I hope that I'm not explaining this incorrectly, but the timestamp will be converted according to RFC2822 in time zone 
-zero (0). In Germany, for example, the resultant DateTime value will always be “behind” (as Germany is in a different 
-time zone). You're better off converting the timestamp using ISO8601, so that the correct time zone is used. For my 
-part, I wrote my own ViewHelper to use this method: Extbase uses this ISO format internally too. See:
+base
+~~~~
+:aspect:`Variable type`
+    Mixed
 
-::
+:aspect:`Description`
+    A DateTime object or a string this ViewHelper converts to a DateTime object. This base can be an integer meant to represent a Unix timestamp. As of TYPO3 CMS 7, this ViewHelper uses base as the $now parameter in PHP's strtotime() function (http://php.net/manual/en/function.strtotime.php), where base provides a starting time for calculating textual relative time descriptions.
 
- DataMapper->mapDateTime()
+:aspect:`Default value`
+    Now
 
-Excerpt: return new DateTime(date('c', $timestamp));
+:aspect:`Mandatory`
+    No
 
-I'm not quite sure why this hasn't been implemented in this ViewHelper.
-
-Example
+Examples
 --------
+
+In these examples, dateObject could also be a string or integer. For instance, try 'now' for dateObject.
+
+Day/month/year produced from day.month.year
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
  <f:format.date date="17.01.1979" format="d/m/y" />
 
-Example using a timestamp
--------------------------
+Unix timestamp into day.month.year
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
  <f:format.date format="d.m.Y">@1334439765</f:format.date>
+ <f:format.date format="d.m.Y">1334439765</f:format.date>
 
-As mentioned: take care to take your national/continental time zone into account when using this ViewHelper.
+Format and base defaults
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+ <f:format.date>{dateObject}</f:format.date>
+ <f:format.date>now</f:format.date>
+
+Hours:minutes
+~~~~~~~~~~~~~
+
+::
+
+ <f:format.date format="H:i">{dateObject}</f:format.date>
+
+A year ago from the base time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+ <f:format.date format="Y" base="{dateObject}">-1 year</f:format.date>
+ <f:format.date format="Y-m-d" base="2016-06-06">-1 year</f:format.date>
+ <f:format.date format="Y-m-d" base="yesterday">-1 year</f:format.date>
+ <f:format.date format="Y-m-d H:i:s" base="1334439765">-1 year</f:format.date>
+ <f:format.date format="Y-m-d H:i:s" base="@1334439765">-1 year</f:format.date>
+
+A more complex textual relative time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+ <f:format.date format="d.m.Y - H:i:s">+1 week 2 days 4 hours 2 seconds</f:format.date>
+
+Localized time using strftime syntax
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+ <f:format.date format="%d. %B %Y">{dateObject}</f:format.date>
+ <f:format.date format="%d. %B %Y">now</f:format.date>
+
+Inline notation
+~~~~~~~~~~~~~~~
+
+::
+
+ {f:format.date(date: dateObject)}
+ {f:format.date(date: dateObject format: "%d. %B %Y")}
+ {f:format.date(date: "now" format: "%c")}
+
+Another inline notation
+~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+ {dateObject -> f:format.date()}
+ {dateObject -> f:format.date(format: 'Y-m-d H:i:s')}
+


### PR DESCRIPTION
This ViewHelper now offers a new property, "base", and has format syntax options available from date() as well as strftime(). Here is an updated page for f:format.date, describing the new property and syntax options and giving more examples.