### PR TITLE
Fix typo in description of property includeJsFiles

### DIFF
--- a/Documentation/Fluid/ViewHelper/Be/Container.rst
+++ b/Documentation/Fluid/ViewHelper/Be/Container.rst
@@ -218,7 +218,7 @@ includeJsFiles
     Array
 
 :aspect:`Description`
-    Using addJsFile will only allow you to bind in a single JavaScript asset file. Using includeCssFiles allows you to 
+    Using addJsFile will only allow you to bind in a single JavaScript asset file. Using includeJsFiles allows you to 
     bind multiple files.
 
 :aspect:`Default value`


### PR DESCRIPTION
the description of the property 'includeJsFiles' read "Using *includeCssFiles* allows you to bind multiple files.". This is clearly an error. I changed it into *includeJsFiles*