### PR TITLE
Little syntax-error

### DIFF
--- a/Documentation/Fluid/ViewHelper/Translate.rst
+++ b/Documentation/Fluid/ViewHelper/Translate.rst
@@ -111,7 +111,7 @@ With placeholders
 
 In the template::
 
- <f:translate key="LLL:fileadmin/lang/locallang.xml:domain_model.bestfilm" arguments="{0: 'Back to the Future}" />
+ <f:translate key="LLL:fileadmin/lang/locallang.xml:domain_model.bestfilm" arguments="{0: 'Back to the Future'}" />
 
 In locallang.xlf::
 


### PR DESCRIPTION
 <f:translate key="LLL:fileadmin/lang/locallang.xml:domain_model.bestfilm" arguments="{0: 'Back to the Future'}" />

behind Future -> ' added