### PR TITLE
Argument cropVariant was missing from f:image

### DIFF
--- a/Documentation/Fluid/ViewHelper/Image.rst
+++ b/Documentation/Fluid/ViewHelper/Image.rst
@@ -16,7 +16,7 @@ Inline usage example
 
 ::
 
-   {f:image(additionalAttributes: {foo: 'bar'}, data: {foo: 'bar'}, src: 'NULL', width: 'NULL', height: 'NULL', minWidth: 123, minHeight: 123, maxWidth: 123, maxHeight: 123, treatIdAsReference: 1, image: [anySimpleType], crop: [anySimpleType], absolute: 1, class: 'NULL', dir: 'NULL', id: 'NULL', lang: 'NULL', style: 'NULL', title: 'NULL', accesskey: 'NULL', tabindex: 123, onclick: 'NULL', alt: 'NULL', ismap: 'NULL', longdesc: 'NULL', usemap: 'NULL')}
+   {f:image(additionalAttributes: {foo: 'bar'}, data: {foo: 'bar'}, src: 'NULL', width: 'NULL', height: 'NULL', minWidth: 123, minHeight: 123, maxWidth: 123, maxHeight: 123, treatIdAsReference: 1, image: [anySimpleType], crop: [anySimpleType], cropVariant: 'default', absolute: 1, class: 'NULL', dir: 'NULL', id: 'NULL', lang: 'NULL', style: 'NULL', title: 'NULL', accesskey: 'NULL', tabindex: 123, onclick: 'NULL', alt: 'NULL', ismap: 'NULL', longdesc: 'NULL', usemap: 'NULL')}
 
 
 Exclusive properties of the HTML tag
@@ -161,6 +161,20 @@ crop
 
 :aspect:`Default value`
     NULL
+
+:aspect:`Mandatory`
+    No
+
+cropVariant
+~~~~
+:aspect:`Variable type`
+    string
+
+:aspect:`Description`
+    Select a cropping variant, in case multiple croppings have been specified or stored in FileReference
+
+:aspect:`Default value`
+    'default'
 
 :aspect:`Mandatory`
     No

--- a/Documentation/Fluid/ViewHelper/Uri/Image.rst
+++ b/Documentation/Fluid/ViewHelper/Uri/Image.rst
@@ -53,6 +53,34 @@ height
 
 :aspect:`Mandatory`
     No
+    
+crop
+~~~~
+:aspect:`Variable type`
+    anySimpleType
+
+:aspect:`Description`
+    Overrule cropping of image (setting to FALSE disables the cropping set in FileReference)
+
+:aspect:`Default value`
+    NULL
+
+:aspect:`Mandatory`
+    No
+    
+cropVariant
+~~~~~~~~~~~
+:aspect:`Variable type`
+    string
+
+:aspect:`Description`
+    Select a cropping variant, in case multiple croppings have been specified or stored in FileReference
+
+:aspect:`Default value`
+    'default'
+
+:aspect:`Mandatory`
+    No
 
 minWidth
 ~~~~~~~~


### PR DESCRIPTION
The f:image ViewHelper has the argument cropVariant to select a cropVariant stored in the File Reference (https://github.com/TYPO3/TYPO3.CMS/blob/master/typo3/sysext/fluid/Classes/ViewHelpers/Uri/ImageViewHelper.php#L79)

This was not in the documentation. Had it been it could have spared me some hours of searching. So I'm adding it to help others who might stumble upon the same problem I had.