### PR TITLE
Remove "data" attribute

### DIFF
--- a/Documentation/Fluid/UniversalTagAttributes.rst
+++ b/Documentation/Fluid/UniversalTagAttributes.rst
@@ -140,19 +140,3 @@ onclick
 
 :aspect:`Mandatory`
     No
-
-data
-----
-
-:aspect:`Variable type`
-    Array
-
-:aspect:`Description`
-    Adds the "data-*" attribute to the tag. New since TYPO3 7 LTS.
-    *Example:* `data="{foo:'bar'}"` produces `data-foo="bar"`
-
-:aspect:`Default value`
-    NULL
-
-:aspect:`Mandatory`
-    No


### PR DESCRIPTION
"data" was introduced in 7 LTS and should be removed in 6_2 branch of the documentation.