### PR TITLE
take out marketing speech

### DIFF
--- a/Documentation/Extbase/Step2SystemCheck/Typo3.rst
+++ b/Documentation/Extbase/Step2SystemCheck/Typo3.rst
@@ -4,9 +4,7 @@ TYPO3
 =====
 
 Extbase has been delivered as a system extension since TYPO 4.3.0 and it has been developed 
-in parallel with the former TYPO3 FLOW, which has now the name Neos Flow. The version numbers of Extbase and Fluid match the version number of TYPO3 core since 4.6.0.
+in parallel with the former TYPO3 FLOW, which then was a TYPO3 Association sponsored project. The version numbers of Extbase and Fluid match the version number of TYPO3 core since 4.6.0.
 
 Although Extbase is available in TYPO3 since version 4.3.0, we recommend that you use 
-the newest possible version - at the very least, 8.7.x. Where performance and security are critical, 
-there the newest versions of TYPO3 are essential. Fluid templates are compiled to PHP since 
-TYPO3 4.6, which allowed a performance increase of around 200–500%.
+the newest possible version - at the very least, 8.7.x. Where performance and security are critical, the newest versions of TYPO3 are essential.


### PR DESCRIPTION
" Fluid templates are compiled to PHP since 
TYPO3 4.6, which allowed a performance increase of around 200–500%."
nobody cares, its 5 years after.