### PR TITLE
PHP Version 5.3.2? just kill this part

### DIFF
--- a/Documentation/Extbase/Step2SystemCheck/Php.rst
+++ b/Documentation/Extbase/Step2SystemCheck/Php.rst
@@ -3,13 +3,6 @@
 PHP
 ===
 
-Although TYPO3 4.5 ran fine using PHP 5.2, we recommend that you use the newest possible 
-stable version of PHP - at least 5.3.2. Newer versions of TYPO3 - since 6.0 - make use of 
-PHP namespacing, which requires PHP 5.3.8 (or newer, wherever possible).
-
-TYPO3 4.5 could run in an environment with a PHP memory_limit of 64MB. Newer versions of 
-TYPO3 benefit from more memory, so your system should allow a setting of at least 128MB.
-
 If you're using xdebug, you might run into difficulty because of the number of nested 
 Partials. This produces the following error message::
 


### PR DESCRIPTION
Active Support Version is 7.1, 5.6 is still working, but will be over in 7 months.
http://php.net/supported-versions.php

the xdebud thing I don't know, if this is still the case