### PR TITLE
TASK: Fix $_EXTKEY usage in docs

### DIFF
--- a/Documentation/Extbase/Step3Documentation/Bootstrap.rst
+++ b/Documentation/Extbase/Step3Documentation/Bootstrap.rst
@@ -9,7 +9,7 @@ caches, and the activation of the persistence layer.
 This initialisation process is prepared in ext_localconf.php::
 
  Tx_Extbase_Utility_Extension::configurePlugin(
-   $_EXTKEY,
+   'Vendor.ext_key',
    'Products',
    array(
      'Product' => 'list, show',

--- a/Documentation/Fluid/ViewHelper/Be/Buttons/Csh.rst
+++ b/Documentation/Fluid/ViewHelper/Be/Buttons/Csh.rst
@@ -72,7 +72,7 @@ Here's an example of how the configuration might appear::
 
    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addLLrefForTCAdescr(
       '_MOD_web_SfextbaseExtbase',
-      'EXT:' . $_EXTKEY . '/Resources/Private/Language/locallang_extbase.xlf'
+      'EXT:ext_key/Resources/Private/Language/locallang_extbase.xlf'
    );
 
 


### PR DESCRIPTION
As $_EXTKEY is more or less deprecated and will be removed in the
future. It's recommended to use the extension key as a string.

Therefore all examples were adjusted, including all mentions of the
variable.