### PR TITLE
Fixed viewhelper casing in title

### DIFF
--- a/Documentation/Fluid/ViewHelper/Be/InfoBox.rst
+++ b/Documentation/Fluid/ViewHelper/Be/InfoBox.rst
@@ -1,7 +1,7 @@
 .. include:: ../../../Includes.txt
 
 ============
-f:be.InfoBox
+f:be.infobox
 ============
 
 View helper for rendering a styled content infobox markup.


### PR DESCRIPTION
#111 The viewhelper casing in the title showed an invalid casing, which leads to render error if used.