### PR TITLE
Add inline notation for if ViewHelper

### DIFF
--- a/Documentation/Fluid/ViewHelper/If.rst
+++ b/Documentation/Fluid/ViewHelper/If.rst
@@ -111,3 +111,19 @@ Simple examples
 If there are no `f:then` or `f:else` ViewHelpers in use, the content between the `f:if` ViewHelpers will only be output if 
 the comparison returns a positive result. If you need to use the full if-then-else construct, then you'll have to 
 use the `f:then` / `f:else` ViewHelpers.
+
+Inline notation
+---------------
+You can also use the ViewHelper with an inline notation.
+
+::
+  {f:if(condition: '{numberVar} == 1', then: 'active', else: 'disable')}
+  {f:if(condition: varName, then: 'varName is set')}
+  {f:if(condition: '{varA} && {varB}', then: 'both set')}
+  {f:if(condition: '{foo} == \'bar\'', then: 'var foo is equal to string bar')}
+  {f:if(condition: '{foo} == "bar"', then: 'var foo is equal to string bar')}
+
+For example to output the class attribute of an html element
+
+::
+  <span class="product-headline {f:if(condition: isHighlight, then: 'highlight-headline')}">{headline}</span>

--- a/Documentation/Fluid/ViewHelper/If.rst
+++ b/Documentation/Fluid/ViewHelper/If.rst
@@ -114,13 +114,13 @@ use the `f:then` / `f:else` ViewHelpers.
 
 Inline notation
 ---------------
-You can also use the ViewHelper with an inline notation.
+You can also use the ViewHelper with :ref:`inline notation <inline-notation-vs-tag-based-notation>`.
 
 ::
 
    {f:if(condition: '{numberVar} == 1', then: 'active', else: 'disable')}
-   {f:if(condition: varName, then: 'varName is set')}
-   {f:if(condition: '{varA} && {varB}', then: 'both set')}
+   {f:if(condition: varName, then: 'varName evaluates to true')}
+   {f:if(condition: '{varA} && {varB}', then: 'both varA and varB evaluate to true')}
    {f:if(condition: '{foo} == \'bar\'', then: 'var foo is equal to string bar')}
    {f:if(condition: '{foo} == "bar"', then: 'var foo is equal to string bar')}
 

--- a/Documentation/Fluid/ViewHelper/If.rst
+++ b/Documentation/Fluid/ViewHelper/If.rst
@@ -117,13 +117,15 @@ Inline notation
 You can also use the ViewHelper with an inline notation.
 
 ::
-  {f:if(condition: '{numberVar} == 1', then: 'active', else: 'disable')}
-  {f:if(condition: varName, then: 'varName is set')}
-  {f:if(condition: '{varA} && {varB}', then: 'both set')}
-  {f:if(condition: '{foo} == \'bar\'', then: 'var foo is equal to string bar')}
-  {f:if(condition: '{foo} == "bar"', then: 'var foo is equal to string bar')}
+
+   {f:if(condition: '{numberVar} == 1', then: 'active', else: 'disable')}
+   {f:if(condition: varName, then: 'varName is set')}
+   {f:if(condition: '{varA} && {varB}', then: 'both set')}
+   {f:if(condition: '{foo} == \'bar\'', then: 'var foo is equal to string bar')}
+   {f:if(condition: '{foo} == "bar"', then: 'var foo is equal to string bar')}
 
 For example to output the class attribute of an html element
 
 ::
-  <span class="product-headline {f:if(condition: isHighlight, then: 'highlight-headline')}">{headline}</span>
+
+   <span class="product-headline {f:if(condition: isHighlight, then: 'highlight-headline')}">{headline}</span>

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -46,6 +46,7 @@ use_opensearch       =
 [intersphinx_mapping]
 
 # t3coreapi = https://docs.typo3.org/typo3cms/CoreApiReference/
+t3extbasebook = https://docs.typo3.org/typo3cms/ExtbaseFluidBook/
 # t3tsconfig = https://docs.typo3.org/typo3cms/TSconfigReference/
 t3tsref = https://docs.typo3.org/typo3cms/TyposcriptReference/
 # t3api = http://typo3.org/api/typo3cms/


### PR DESCRIPTION
In daily work we often use inline notation of the if ViewHelper. So far there was no examples provided for this, so I added some.