### PR TITLE
Added page about f:variable

### DIFF
--- a/Documentation/Fluid/ViewHelper/Alias.rst
+++ b/Documentation/Fluid/ViewHelper/Alias.rst
@@ -1,5 +1,7 @@
 .. include:: ../../Includes.txt
 
+.. _vh-f-alias:
+
 f:alias
 =======
 

--- a/Documentation/Fluid/ViewHelper/Index.rst
+++ b/Documentation/Fluid/ViewHelper/Index.rst
@@ -44,3 +44,4 @@ The power of Fluid is the usage of ViewHelpers. There are many of them, for all 
    Switch
    Then
    Translate
+   Variable

--- a/Documentation/Fluid/ViewHelper/Variable.rst
+++ b/Documentation/Fluid/ViewHelper/Variable.rst
@@ -1,0 +1,80 @@
+.. include:: ../../Includes.txt
+
+f:variable
+===========
+
+Assigns one template variable which will exist also after the ViewHelper is done rendering, i.e. adds template variables.
+
+If you require a variable assignment which does not exist in the template after a piece of Fluid code is rendered, consider using `f:alias` instead.
+
+Properties
+----------
+
+name
+~~~
+:aspect:`Variable type`
+    String
+
+:aspect:`Description`
+    Name of variable to create
+
+:aspect:`Default value`
+    NULL
+
+:aspect:`Mandatory`
+    Yes
+
+value
+~~~~~~~
+:aspect:`Variable type`
+    Mixed
+
+:aspect:`Description`
+   Value to assign. If not in arguments then taken from tag content
+
+:aspect:`Default value`
+    NULL
+
+:aspect:`Mandatory`
+    No
+
+Examples
+--------
+
+Tag notation
+~~~~~~~~~~~~
+
+::
+
+ <f:variable name="myvariable" value="some value" />
+
+Tag notation II
+~~~~~~~~~~~~~~~
+
+::
+
+ <f:variable name="myvariable">some value</f:variable>
+
+Inline notation
+~~~~~~~~~~~~~~~
+
+::
+
+ {f:variable(name: 'myvariable', value: 'some value')}
+
+Simple math
+~~~~~~~~~~~
+
+::
+
+ {f:variable(name: 'mycount', value: 0)}
+ {mycount}
+
+> Outout is "0"
+
+::
+
+ {f:variable(name: 'mycount', value: '{mycount + 1}')}
+ {mycount}
+
+> Outout is now "1"

--- a/Documentation/Fluid/ViewHelper/Variable.rst
+++ b/Documentation/Fluid/ViewHelper/Variable.rst
@@ -78,11 +78,11 @@ Simple math
  {f:variable(name: 'mycount', value: 0)}
  {mycount}
 
-> Outout is "0"
+> Output is "0"
 
 ::
 
  {f:variable(name: 'mycount', value: '{mycount + 1}')}
  {mycount}
 
-> Outout is now "1"
+> Output is now "1"

--- a/Documentation/Fluid/ViewHelper/Variable.rst
+++ b/Documentation/Fluid/ViewHelper/Variable.rst
@@ -11,7 +11,8 @@ Properties
 ----------
 
 name
-~~~
+~~~~
+
 :aspect:`Variable type`
     String
 

--- a/Documentation/Fluid/ViewHelper/Variable.rst
+++ b/Documentation/Fluid/ViewHelper/Variable.rst
@@ -5,7 +5,8 @@ f:variable
 
 Assigns one template variable which will exist also after the ViewHelper is done rendering, i.e. adds template variables.
 
-If you require a variable assignment which does not exist in the template after a piece of Fluid code is rendered, consider using `f:alias` instead.
+If you require a variable assignment which does not exist in the template after a piece of Fluid code is rendered,
+consider using :ref:`vh-f-alias` instead.
 
 Properties
 ----------

--- a/Documentation/Fluid/ViewHelper/Variable.rst
+++ b/Documentation/Fluid/ViewHelper/Variable.rst
@@ -62,6 +62,13 @@ Inline notation
 
  {f:variable(name: 'myvariable', value: 'some value')}
 
+Inline notation II
+~~~~~~~~~~~~~~~~~~
+
+::
+
+ {oldvariable -> f:format.htmlspecialchars() -> f:variable(name: 'newvariable')}
+
 Simple math
 ~~~~~~~~~~~
 


### PR DESCRIPTION
Seems as if no one ever create a page for this viewhelper that's been added to TYPO3 8.6.

