### PR TITLE
Added page about f:spaceless

### DIFF
--- a/Documentation/Fluid/ViewHelper/Index.rst
+++ b/Documentation/Fluid/ViewHelper/Index.rst
@@ -41,6 +41,7 @@ The power of Fluid is the usage of ViewHelpers. There are many of them, for all 
    RenderChildren
    RenderFlashMessages
    Section
+   Spaceless
    Switch
    Then
    Translate

--- a/Documentation/Fluid/ViewHelper/Spaceless.rst
+++ b/Documentation/Fluid/ViewHelper/Spaceless.rst
@@ -1,0 +1,35 @@
+.. include:: ../../Includes.txt
+
+f:spaceless
+===========
+
+Removes redundant spaces between HTML tags while preserving the whitespace that may be inside HTML tags. Trims the final result before output.
+
+Properties
+----------
+
+This ViewHelper doesn't accept any properties.
+
+Example
+-------
+
+::
+
+ <f:spaceless>
+   <div>
+       <div>
+           <div>text
+
+   text</div>
+       </div>
+   </div>
+ </f:spaceless>
+
+Output
+------
+
+::
+
+ <div><div><div>text
+
+ text</div></div></div>


### PR DESCRIPTION
Seems as if no one ever create a page for this viewhelper that's been added to TYPO3 8.6.